### PR TITLE
Corrected version syntax in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "andyjessop/contact-form-backend",
-    "version": 1.1.0
+    "version": "1.1.0",
     "description": "An endpoint for AJAX-posting a contact form",
     "type": "bolt-extension",
     "require": {


### PR DESCRIPTION
There was a syntactical bug (missing "" around the version number and a missing , at the end of the line). I fixed it with my push.
