### PR TITLE
Fix composer.json error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "andyjessop/contact-form-backend",
-    "version": 1.1.0
+    "version": "1.1.0",
     "description": "An endpoint for AJAX-posting a contact form",
     "type": "bolt-extension",
     "require": {


### PR DESCRIPTION
Missing quotes and a comma, resulted in Bolt refusing to install the plugin
